### PR TITLE
Add missing release commits

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -68,7 +68,7 @@ pipeline {
 							sh "bash -xe .release/scripts/prepare-release.sh -j -b ${env.GIT_BRANCH} -v ${params.DEVELOPMENT_VERSION} infra-gradle-plugin ${params.RELEASE_VERSION}"
 							sh "./gradlew publishPlugins"
 							sh "bash -xe .release/scripts/update-version.sh infra-gradle-plugin ${params.DEVELOPMENT_VERSION}"
-							sh "bash -xe .release/scripts/push-upstream.sh infra-gradle-plugin ${params.RELEASE_VERSION} true"
+							sh "bash -xe .release/scripts/push-upstream.sh infra-gradle-plugin ${params.RELEASE_VERSION} ${env.GIT_BRANCH} true"
 						}
 					}
 				}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.1.0
+version=2.2.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.1.0-SNAPSHOT
+version=2.1.0


### PR DESCRIPTION
as the job published the plugin but didn't push the changes in the end (due to a missing branch parameter in the script)